### PR TITLE
Rename domain into domain_controller.

### DIFF
--- a/resources/domain_controller.rb
+++ b/resources/domain_controller.rb
@@ -1,15 +1,16 @@
 #
 # Author:: Derek Groh (<dgroh@arch.tamu.edu>)
 # Cookbook:: windows_ad
-# Resource:: domain
+# Resource:: domain_controller
 #
 # Copyright:: 2013, Texas A&M
 
-resource_name :windows_ad_domain
-provides :windows_ad_domain
+resource_name :windows_ad_domain_controller
+provides :windows_ad_domain_controller
 
 default_action :create
 
+property :domain, String, required: true
 property :domain_user, String, required: true
 property :domain_pass, String, required: true
 property :parent_domain_name, String
@@ -29,14 +30,14 @@ action :create do
   else
     if Chef::Version.new(node['os_version']) >= Chef::Version.new('6.2')
       cmd = create_command
-      cmd << " -DomainName #{new_resource.name}"
+      cmd << " -DomainName #{new_resource.domain}"
       cmd << " -SafeModeAdministratorPassword (convertto-securestring '#{new_resource.safe_mode_pass}' -asplaintext -Force)"
       cmd << ' -Force:$true'
       cmd << ' -NoRebootOnCompletion' unless new_resource.restart
     else
       cmd = 'dcpromo -unattend'
       cmd << " -newDomain:#{new_resource.type}"
-      cmd << " -NewDomainDNSName:#{new_resource.name}"
+      cmd << " -NewDomainDNSName:#{new_resource.domain}"
       cmd << if !new_resource.restart
                ' -RebootOnCompletion:No'
              else
@@ -48,7 +49,7 @@ action :create do
     Chef::Log.debug("cmd is #{cmd}")
     cmd << format_options(new_resource.options)
 
-    powershell_script "create_domain_#{new_resource.name}" do
+    powershell_script "create_domain_#{new_resource.domain}" do
       code cmd
       returns [0, 1, 2, 3, 4]
     end
@@ -69,7 +70,7 @@ action :delete do
     cmd << ' -DemoteOperationMasterRole' if last_dc?
     cmd << format_options(new_resource.options)
 
-    powershell_script "remove_domain_#{new_resource.name}" do
+    powershell_script "remove_domain_#{new_resource.domain}" do
       code cmd
     end
   end
@@ -77,7 +78,8 @@ end
 
 action_class do
   def exists?
-    ldap_path = new_resource.name.split('.').map! { |k| "dc=#{k}" }.join(',')
+    # [adsi]::Exists('LDAP://cn=dcbackup,ou=domain controllers,dc=ad,dc=datadogqalab,dc=com')
+    ldap_path = "cn=" + new_resource.name + ",ou=domain controllers," + new_resource.domain.split('.').map! { |k| "dc=#{k}" }.join(',')
     check = Mixlib::ShellOut.new("powershell.exe -command [adsi]::Exists('LDAP://#{ldap_path}')").run_command
     check.stdout.match('True')
   end
@@ -85,7 +87,7 @@ action_class do
   def computer_exists?
     comp = Mixlib::ShellOut.new('powershell.exe -command "get-wmiobject -class win32_computersystem -computername . | select domain"').run_command
     stdout = comp.stdout.downcase
-    stdout.include?(new_resource.name.downcase)
+    stdout.include?(new_resource.domain.downcase)
   end
 
   def last_dc?

--- a/resources/domain_controller.rb
+++ b/resources/domain_controller.rb
@@ -78,16 +78,11 @@ end
 
 action_class do
   def exists?
-    # [adsi]::Exists('LDAP://cn=dcbackup,ou=domain controllers,dc=ad,dc=datadogqalab,dc=com')
+    # Example query with domain controller "mydc" and domain "test.contoso.com"
+    # [adsi]::Exists('LDAP://cn=mydc,ou=domain controllers,dc=test,dc=contoso,dc=com')
     ldap_path = "cn=" + new_resource.name + ",ou=domain controllers," + new_resource.domain.split('.').map! { |k| "dc=#{k}" }.join(',')
     check = Mixlib::ShellOut.new("powershell.exe -command [adsi]::Exists('LDAP://#{ldap_path}')").run_command
     check.stdout.match('True')
-  end
-
-  def computer_exists?
-    comp = Mixlib::ShellOut.new('powershell.exe -command "get-wmiobject -class win32_computersystem -computername . | select domain"').run_command
-    stdout = comp.stdout.downcase
-    stdout.include?(new_resource.domain.downcase)
   end
 
   def last_dc?


### PR DESCRIPTION
### Description

This PR renames the resource `domain` into `domain_controller` so that multiple domain controller can exist within a domain. Previously, if the domain already exists, the DC would not be promoted since the property `exists` would return true.

### Issues Resolved

N/A

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
